### PR TITLE
Implement `make_bip32_path` macro

### DIFF
--- a/src/crypto_helpers.rs
+++ b/src/crypto_helpers.rs
@@ -23,7 +23,7 @@ macro_rules! make_bip32_path {
         // We are looking for 5 numbers, separated by `/`.
         // Those numbers are represented in ASCII bytes (e.g `[49, 48, 51]` represents the number `103`).
         // We are going to parse the string once, summing the bytes when we encounter them to create a number
-        // and resetting our counter everytime we get to a separator (i.e. not a byte that represent an ASCII number).
+        // and resetting our counter everytime we get to a separator (i.e. a byte that does not represent an ASCII number).
         while (j < path.len()) {
             // Check if this byte represents a number in ASCII.
             while (i < $bytes.len() && $bytes[i] >= ZERO && $bytes[i] <= NINE) {

--- a/src/crypto_helpers.rs
+++ b/src/crypto_helpers.rs
@@ -1,11 +1,6 @@
 use nanos_sdk::bindings::*;
 use nanos_sdk::ecc::{CurvesId, DEREncodedECDSASignature};
 
-/// ASCII value of the character 0.
-const ZERO: u8 = 48;
-/// ASCII value of the character 9.
-const NINE: u8 = 57;
-
 /// Helper macro that creates an array from the ASCII values of a correctly formatted derivation path.
 /// Format expected: `b"44'/coin_type'/account'/change/address"`.
 ///
@@ -26,9 +21,9 @@ macro_rules! make_bip32_path {
         // and resetting our counter everytime we get to a separator (i.e. a byte that does not represent an ASCII number).
         while (j < path.len()) {
             // Check if this byte represents a number in ASCII.
-            while (i < $bytes.len() && $bytes[i] >= ZERO && $bytes[i] <= NINE) {
+            while (i < $bytes.len() && $bytes[i].is_ascii_digit()) {
                 // It does: add it to the accumulator (taking care to substract the ASCII value of 0).
-                acc = acc * 10 + $bytes[i] as u32 - ZERO as u32;
+                acc = acc * 10 + $bytes[i] as u32 - b'0' as u32;
                 i += 1;
             }
             // We've effectively parsed a number: add it to `path`.
@@ -38,7 +33,7 @@ macro_rules! make_bip32_path {
             // Keep going until we either:
             // 1. Find a new number.
             // 2. Reach the end of the bytes.
-            while (i < $bytes.len() && ($bytes[i] <= ZERO || $bytes[i] >= NINE)) {
+            while (i < $bytes.len() && $bytes[i].is_ascii_digit()) {
                 i += 1;
             }
             // Repeat that for the next element in `path`.

--- a/src/crypto_helpers.rs
+++ b/src/crypto_helpers.rs
@@ -33,7 +33,7 @@ macro_rules! make_bip32_path {
             // Keep going until we either:
             // 1. Find a new number.
             // 2. Reach the end of the bytes.
-            while (i < $bytes.len() && $bytes[i].is_ascii_digit()) {
+            while (i < $bytes.len() && !$bytes[i].is_ascii_digit()) {
                 i += 1;
             }
             // Repeat that for the next element in `path`.


### PR DESCRIPTION
## What this does
This PR addresses a `TODO` that was left in the code. The requested feature was to create a macro that derives a path given a standard bip32 description (in bytes).

## How the code works

The macro does not validate the input and is not safe (as described in the code documentation) (out of bounds + potential infinite loop).
For a detail description of the macro, please see the code (it should be self documented). Code is verbose on purpose and could of course be modified to remove some comments.

## Additional Info

I would have liked to add some tests for this macro, however it seems like adding tests in `no_std` environment isn't as straightforward as I thought it would be.
I found a [blog post](https://os.phil-opp.com/testing/#testing-in-rust) that provided a little bit of guidance and tried to follow it, however I kept on getting some:
```
[*] using SDK version 1.6
[*] patching svc instruction at 0x40003acc
[*] patching svc instruction at 0x40004124
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

Please let me know if you know a way to add some unit-tests! :)