### PR TITLE
Update runner to sdk 2.0

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,7 +3,7 @@ rustflags = [
   "-C", "relocation-model=ropi",
   "-C", "link-arg=-Tscript.ld",
 ]
-runner = "speculos.py --display text -k 1.6"
+runner = "speculos.py --display text -k 2.0"
 
 [build]
 target = "thumbv6m-none-eabi"


### PR DESCRIPTION
Current runner is using `-k 1.6` which is the old SDK. Since this rust SDK has been updated to support C SDK 2.0, I think the runner should default to sdk 2.0 too :)