### PR TITLE
Added target file for Nano S.

### DIFF
--- a/nanos.json
+++ b/nanos.json
@@ -1,0 +1,26 @@
+{
+    "abi": "eabi",
+    "arch": "arm",
+    "atomic-cas": false,
+    "c-enum-min-bits": 8,
+    "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
+    "emit-debug-gdb-scripts": false,
+    "executables": true,
+    "features": "+strict-align",
+    "frame-pointer": "always",
+    "linker": "rust-lld",
+    "linker-flavor": "ld.lld",
+    "llvm-target": "thumbv6m-none-eabi",
+    "panic-strategy": "abort",
+    "pre-link-args": {
+        "ld.lld": [
+            "-Tnanos_layout.ld",
+            "-Tlink.ld"
+        ]
+    },
+    "relocation-model": "ropi",
+    "singlethread": true,
+    "target-pointer-width": "32",
+    "os": "nanos",
+    "target-family": [ "bolos" ]
+  }


### PR DESCRIPTION
Perhaps the other target files for Nano X and Nano S Plus can be added, because the Rust ledger-nanos-sdk provides them too.